### PR TITLE
Replaced cas info command with cas --version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Thanks! -->
 
 **Environment**
 ```shell
-# run "cas info" and copy/paste the output here
+# run "cas --version" and copy/paste the output here
 ```
 
 **Additional info (any other context about the problem)**


### PR DESCRIPTION
My tiny 'thank you' contribution to CAS after having received such a fast solution to my problems reported [here](https://github.com/codenotary/cas/issues/275)